### PR TITLE
Publish ReadFlow Daily 2026-06-11

### DIFF
--- a/_posts/2026-06-11-readflow-daily.md
+++ b/_posts/2026-06-11-readflow-daily.md
@@ -1,0 +1,336 @@
+---
+layout:     post
+title:      ReadFlow Daily 2026-06-11
+subtitle:   AI 阅读日报
+date:       2026-06-11
+author:     Eric.Y
+catalog: true
+tags:
+    - ReadFlow
+    - Daily
+    - Agent
+    - Codex
+    - AI Engineering
+    - Product
+    - Claude
+    - Memory
+---
+
+# ReadFlow Daily 2026-06-11
+
+今天从 30 篇候选里留下 21 篇：13 篇进入今日重点，8 篇适合稍后细读。
+这份版本是给博客阅读的整理稿，只保留判断、摘要、配图和原文入口。
+
+![驾驭工程：在智能体优先的世界中利用 Codex](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_1.png)
+
+## 今日重点
+
+### 1. Claude Fable 5 的初步印象
+
+![Claude Fable 5 的初步印象](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_2.jpg)
+
+Simon Willison 对 Claude Fable 5 的初步上手评测显示，这是一个强大、昂贵且知识密集的模型，擅长处理复杂的编程任务——他在一天内就用它构建了一个完整的 CPython WASM 沙箱，并为其 LLM 库交付了重要功能。
+
+值得记下的点：
+- Simon Willison 在进行了 5.5 小时的测试后，分享了他对 Anthropic 新模型 Claude Fable 5 的初步印象。他强调了该模型庞大的知识量（从其能详细列出他自己的开源项目可见一斑）、高昂的成本（每百万 token 10/50 美元）以及令人印象深刻的编码能力。Willison 详述了两个重大成功案例：首先…
+- Claude Fable 5 展现出比其前代 Opus 4.8 显著更深的知识储备。
+
+我把它放在这里，是因为：Claude 新模型的真实上手评测，包含复杂编程任务、成本与能力边界，适合作为模型能力观察基准。
+
+Agent, Claude, AI Engineering · simonwillison.net · 发布时间：2026-06-10 07:59 · [原文](https://simonwillison.net/2026/Jun/9/claude-fable-5/#atom-everything)
+
+### 2. Salesforce 从 20，000 个企业智能体部署中学到的经验
+
+![Salesforce 从 20，000 个企业智能体部署中学到的经验](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_3.png)
+
+Salesforce 分享了从 20，000 个企业智能体部署中获得的宝贵经验，揭示了 90% 的工作发生在上线之后，并提供了一套构建能在生产环境中存活下来的智能体的实用指南。
+
+值得记下的点：
+- 本文提炼了 Salesforce 从 20，000 个企业级 Agentforce 部署中获得的经验，形成了一份构建能带来实际商业价值的 AI 智能体的实用指南。文章指出，团队犯的最大错误是将上线视为终点，而实际上 90% 的努力都在上线之后。文章分为三部分：上线前的基础（从小处着手，将智能体与解决率等关键绩效指标挂钩，并实施输入/输出护…
+- 构建 AI 智能体 90% 的工作发生在上线之后，而非之前。
+
+我把它放在这里，是因为：来自大规模企业 Agent 部署的一线经验，尤其适合沉淀生产化智能体的上线后运营原则。
+
+Agent, AI Engineering, Business · blog.bytebytego.com · 发布时间：2026-06-09 23:07 · [原文](https://blog.bytebytego.com/p/what-salesforce-learned-from-20000)
+
+### 3. 多媒体积木块
+
+![多媒体积木块](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_4.png)
+
+本文展示了一个 AI 智能体如何通过两个 Hugging Face Space 的 `agents.md` 端点（图像生成和 3D 重建）串联工作，构建了一个巴黎纪念碑 3D 画廊，并论证这种模式预示了未来多媒体软件将由可组合、有文档的积木块组装而成。
+
+值得记下的点：
+- 作者描述了一个动手实验：让一个编程智能体构建一个巴黎纪念碑的 3D 画廊。该智能体从未直接使用图像生成器或 3D 工具；相反，它通过读取两个 Hugging Face Space 的 `agents.md` 文件来调用它们——一个用于图像生成，另一个用于单图到 3D 高斯泼溅重建。`agents.md` 文件提供了纯文本的 API 模式…
+- 积木块经济现已适用于多媒体 AI，而不仅仅是代码库。
+
+我把它放在这里，是因为：用 agents.md 串联多媒体工具的案例，和可组合智能体工具生态直接相关。
+
+Agent · huggingface.co · 发布时间：2026-06-09 18:51 · [原文](https://huggingface.co/blog/mishig/spaces-agents-md)
+
+### 4. Claude Code 一周年复盘：从辅助写代码到自主智能体工作流
+
+![Claude Code 一周年复盘：从辅助写代码到自主智能体工作流](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_5.jpg)
+
+这场 Claude Code 一周年官方复盘指出，AI 编程已经从单次辅助任务进入可验证、自主运行的多智能体工作流阶段，并正在重塑软件团队与企业流程。
+
+值得记下的点：
+- 在这场 Claude 官方对话中，两位讲者回顾 Claude Code 发布第一年的变化，重点讨论它如何从简单的开发辅助工具，演进为由智能体、routine、验证循环、Auto Mode、远程控制和上下文极简主义共同组成的工作系统。内容最有价值的部分来自团队内部的一手实践：智能体的验证不应只停留在单元测试、lint 或类型检查，而应能真正…
+- Claude Code 正从工具使用走向智能体编排 讲者描述了从一次性编码任务，到由智能体树、routine 和循环共同协调大量并行工作的转变。
+
+我把它放在这里，是因为：Claude Code 从辅助工具走向自主工作流的复盘，贴合当前 Agent 工程与技能化工作流建设。
+
+Claude, AI Engineering, Product · youtube.com · 发布时间：2026-06-09 00:31 · [原文](https://www.youtube.com/watch?v=Hth_tLaC2j8)
+
+### 5. 循环工程
+
+![循环工程](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_6.jpeg)
+
+循环工程是一种设计自主系统的实践，该系统代替你向编程智能体发出提示词，用递归、自我维持的发现、执行和验证循环取代手动提示。
+
+值得记下的点：
+- 本文介绍并深入解析了 AI 编程智能体的“循环工程”概念。作者认为，手动提示智能体的时代正在让位于设计管理整个工作流的自主循环。循环的核心由五个构建块组成：自动化（定时发现与分类）、工作树（无文件冲突的并行执行）、技能（持久化项目知识）、插件/连接器（通过 MCP 与现实世界工具集成）以及子智能体（将制造者与检查者分离）。第六个关键组件是…
+- 循环工程用自主、递归的智能体系统取代了手动提示。
+
+我把它放在这里，是因为：Loop Engineering 把手动提示升级为自动发现、执行、验证循环，是今天最值得关注的工程方法论。
+
+Claude, Codex, MCP, AI Engineering · addyo.substack.com · 发布时间：2026-06-08 22:31 · [原文](https://addyo.substack.com/p/loop-engineering)
+
+### 6. 驾驭工程：在智能体优先的世界中利用 Codex
+
+![驾驭工程：在智能体优先的世界中利用 Codex](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_1.png)
+
+OpenAI 工程师详细介绍了为期五个月的实验：使用 Codex 智能体，以零手动编写代码的方式构建一个生产级软件产品，实现了 10 倍的速度提升，并将工程师的角色重新定义为系统设计师和反馈循环架构师。
+
+值得记下的点：
+- 本文记录了 OpenAI 一个工程团队为期五个月的实验，他们完全使用 Codex 生成的代码构建了一个真实的软件产品，涵盖从应用程序逻辑到 CI 配置和文档的方方面面。由 3 到 7 名工程师组成的团队平均每人每天提交 3.5 个拉取请求，在 1500 个 PR 中总计生成了约一百万行代码。核心见解是，工程师的工作从编写代码转变为设计环境…
+- 工程师的角色从编写代码转变为为智能体设计环境和反馈循环。
+
+我把它放在这里，是因为：OpenAI 关于 Harness Engineering 的实践文章，直接关联 Codex、验证循环和 Agent-first 工程组织。
+
+Agent, Codex, AI Engineering, Product · openai.com · 发布时间：2026-06-06 02:20 · [原文](https://openai.com/index/harness-engineering/)
+
+### 7. 全栈构建者与高杠杆通才的崛起：Satya Nadella 谈企业 AI 的下一阶段
+
+![全栈构建者与高杠杆通才的崛起：Satya Nadella 谈企业 AI 的下一阶段](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_7.jpg)
+
+Satya Nadella 认为，企业 AI 的真正价值将来自开放的 harness、私有评测、智能体工作流，以及更高杠杆的全栈构建者。
+
+值得记下的点：
+- 这期 Microsoft Build 现场访谈以紧凑而高密度的方式呈现了 Satya Nadella 对 AI 平台下一阶段的判断。他并没有把竞争简化为单一模型之争，而是把 AI 描述成一个生态：企业需要自己的模型 harness、上下文层、工具和私有评测，才能持续积累专有价值。访谈把模型谱系、前沿智能、GitHub Copilot、Mi…
+- 企业 AI 需要开放 harness，而不是被单一模型锁定 Nadella 将 Microsoft 的策略放在模型、上下文、工具和私有评测的组合之上，让企业可以在不同前沿模型之间持续爬坡，同时保留自己的操作痕迹和领域知识。
+
+我把它放在这里，是因为：关于 harness、私有评测和全栈构建者的判断，对企业 AI 平台化很有参考价值。
+
+AI Engineering, Product · youtube.com · 发布时间：2026-06-04 18:00 · [原文](https://www.youtube.com/watch?v=RQE8OS392dU)
+
+### 8. 梦境：更强大的记忆，让 ChatGPT 更贴心
+
+![梦境：更强大的记忆，让 ChatGPT 更贴心](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_8.png)
+
+OpenAI 宣布对 ChatGPT 的记忆系统进行重大升级，采用更具可扩展性的“梦境”架构，可自动从聊天历史中合成记忆，以提升新鲜度、连续性和相关性。
+
+值得记下的点：
+- 这篇来自 OpenAI 的文章详细介绍了 ChatGPT 记忆系统的演进和最新升级。它解释了从最初的“已保存记忆”（手动、基于提示）到“梦境”（自动、后台合成）的转变。这种基于梦境的新架构现已向美国的 Plus 和 Pro 用户推出，其能力更强、计算效率更高，使得免费用户的计算成本降低了 5 倍。文章概述了三个核心记忆目标：延续有用上下文…
+- ChatGPT 的记忆正从手动的“已保存记忆”进化为自动的“梦境”系统。
+
+我把它放在这里，是因为：ChatGPT 记忆系统升级和后台合成机制，适合放入长期记忆/个性化能力观察。
+
+Product, Memory · openai.com · 发布时间：2026-06-04 17:00 · [原文](https://openai.com/index/chatgpt-memory-dreaming)
+
+### 9. 超越组件：为 MCP Apps 设计生成式 UI 与人机协作画布
+
+![超越组件：为 MCP Apps 设计生成式 UI 与人机协作画布](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_9.jpg)
+
+Ruben Casas 解释了为什么 MCP Apps 的生成式 UI 应该从静态组件走向声明式布局、运行时生成组件、安全沙箱交付，以及人类与智能体共享的协作画布。
+
+值得记下的点：
+- 这场 AI Engineer 演讲梳理了 AI 生成界面从早期复制粘贴代码块，到新一代模型生成高保真 UI 的演进，并提出一个核心设计问题：既然模型已经能够写出可用的前端代码，为什么智能体产品仍然主要停留在静态 UI 和聊天框里？Ruben Casas 将答案拆成三层界面架构：智能体把 props 传入预定义组件的静态组件架构，模型生成…
+- 现代模型改变了 UI 生成的基准线 Casas 认为，近期模型在长周期任务和高保真前端工作上已经足够强，旧有的「每个界面都必须由人手工打造」的假设不再成立。
+
+我把它放在这里，是因为：MCP Apps 和生成式 UI 的方向与 Agent 产品交互范式高度相关。
+
+MCP, Product · youtube.com · 发布时间：2026-06-04 01:00 · [原文](https://www.youtube.com/watch?v=hCMrEfPG2Yg)
+
+### 10. OpenAI 如何构建其数据智能体
+
+![OpenAI 如何构建其数据智能体](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_10.png)
+
+本文详细介绍了 OpenAI 数据平台团队如何通过聚焦强大的数据基础设施和丰富的上下文组装层，而非复杂的智能体架构，构建了一个简单可靠的数据智能体。
+
+值得记下的点：
+- 本文深入剖析了 OpenAI 数据平台团队如何构建一个内部数据智能体，以帮助其约 4，000 名用户浏览 90，000 个数据集和 1.5 EB 的数据。核心见解是，智能体本身有意保持简单——一个单一的 LLM（GPT-5.5）搭配一组精心挑选的 13 个工具——而可靠性则来自一个精密的上下文组装层。该层使用了六种上下文来源：表使用元数据…
+- 在强大的数据基础设施支持下，简单的智能体架构就足够了。
+
+我把它放在这里，是因为：OpenAI 内部数据智能体的上下文组装和工具设计，是简单可靠 Agent 架构的好案例。
+
+Agent, Codex, AI Engineering, Memory · blog.bytebytego.com · 发布时间：2026-06-03 22:50 · [原文](https://blog.bytebytego.com/p/how-openai-built-its-data-agent)
+
+### 11. Cisco CX 如何从聊天机器人走向 AI 原生企业智能体队友
+
+![Cisco CX 如何从聊天机器人走向 AI 原生企业智能体队友](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_11.jpg)
+
+Cisco CX 首席架构师 Carlos 讲述了 Cisco 如何把续约聊天机器人演进为基于 LangGraph、面向大规模客户体验工作流的 AI 原生智能体队友。
+
+值得记下的点：
+- 这场会议演讲是一份扎实的生产级案例，展示 Cisco CX 如何为数十亿美元规模的续约业务，从引导式聊天机器人转向 AI 原生队友。Carlos 先解释 Cisco 客户体验背后的业务生命周期，再指出把 AI 叠加到有缺陷的流程上，只会更快放大失败，因此团队改为围绕工作流原生执行来重建系统。最有价值的部分包括精简的 supervisor…
+- Cisco 将企业 AI 从聊天机器人增强，重新定义为工作流原生的队友。
+
+我把它放在这里，是因为：生产级企业 Agent 案例，展示从聊天机器人到工作流队友的迁移路径。
+
+人工智能 · youtube.com · 发布时间：2026-06-03 20:42 · [原文](https://www.youtube.com/watch?v=McZgnvn-e84)
+
+### 12. GitHub Copilot 应用：以智能体为核心的桌面体验
+
+![GitHub Copilot 应用：以智能体为核心的桌面体验](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_12.jpg)
+
+GitHub 宣布推出 Copilot 应用，这是一款以智能体为核心的桌面体验，为管理并行的智能体工作流提供了统一控制中心，具备隔离工作树、画布、沙箱和可扩展的代码审查等功能。
+
+值得记下的点：
+- 这篇来自 GitHub 博客的文章宣布了全新的 GitHub Copilot 应用，这是一款专为智能体开发时代设计的桌面体验。它解决了使用多个 AI 智能体时工作流脱节和上下文切换的问题。该应用引入了一个“我的工作”视图，用于管理跨连接仓库的活动会话、议题和拉取请求。主要功能包括：用于并行智能体会话的隔离 git 工作树、作为双向工作表面…
+- GitHub Copilot 应用是一个新的桌面控制中心，用于并行管理多个 AI 智能体。
+
+我把它放在这里，是因为：Agent-native 桌面体验和并行工作流控制中心，值得跟踪。
+
+Local AI · github.blog · 发布时间：2026-06-03 01:30 · [原文](https://github.blog/news-insights/product-news/github-copilot-app-the-agent-native-desktop-experience/)
+
+### 13. 打造 AI 原生工程组织 | Claude
+
+![打造 AI 原生工程组织 | Claude](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_13.jpg)
+
+本文阐述了 Claude Code 团队如何改造其工程流程——规划、上下文收集、代码审查和团队构成——以在 AI 原生环境中高效运作。
+
+值得记下的点：
+- 作者是 Claude Code 团队的工程负责人，描述了由智能体编程驱动的工程工作流的根本性转变。核心论点是，围绕人类编码时间稀缺性构建的传统流程现已过时。文章详细阐述了四个关键变化领域：从长期路线图转向即时规划；用“先问 Claude”和自动化上下文收集取代“去问原作者”的文化；将人工代码审查聚焦于领域专长，而让 Claude 处理风格…
+- 传统工程流程是围绕人类编码时间成本构建的，现已过时。
+
+我把它放在这里，是因为：Claude Code 团队对 AI 原生工程组织的流程改造总结，和日常研发工作方式直接相关。
+
+Claude, AI Engineering, Product · claude.com · 发布时间：2026-06-03 00:00 · [原文](https://claude.com/blog/running-an-ai-native-engineering-org)
+
+## 值得细读
+
+### 语音智能体能否处理双语客户？前沿 ASR 在语码转换语音上的基准测试
+
+![语音智能体能否处理双语客户？前沿 ASR 在语码转换语音上的基准测试](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_14.png)
+
+本文对前沿 ASR 系统在四种语言对的语码转换语音上进行了基准测试，发现 ElevenLabs Scribe V2、Gemini 3 Flash 和 AssemblyAI 等顶级模型处理双语输入时性能损失小得惊人，而错误主要集中在嵌入的英语片段上。
+
+值得记下的点：
+- 本文介绍了一项系统性基准测试，评估了七种 ASR 系统在企业场景下处理语码转换语音的能力。作者使用 HR 和 IT 支持场景构建了一个涵盖四种语言对（西班牙语-英语、法语-英语、加拿大法语-英语、德语-英语）的合成数据集。他们使用三个指标评估模型：WER、语义 WER（SWER）和答案错误率（AER）。主要发现包括：ElevenLabs…
+- 顶级前沿 ASR 模型处理语码转换语音时性能损失小得惊人。
+
+我把它放在这里，是因为：语音 Agent 的多语种输入能力基准，有应用价值但和今日工程主线稍远。
+
+人工智能 · huggingface.co · 发布时间：2026-06-10 03:38 · [原文](https://huggingface.co/blog/ServiceNow-AI/code-switching)
+
+### Karpathy 评 Claude Fable 5：AI 能力的重大阶跃
+
+![Karpathy 评 Claude Fable 5：AI 能力的重大阶跃](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_15.jpg)
+
+Andrej Karpathy 评测了 Claude Fable 5，称其为值得大版本号提升的阶跃式进步，尤其在处理漫长而复杂的问题求解方面表现突出，并探讨了由此带来的软件需求加速增长。
+
+值得记下的点：
+- Andrej Karpathy 对新发布的 Claude Fable 5 模型进行了定性评测。他确认该模型与 Mythos 底层相同，但增加了安全防护措施。虽然基准测试已显示其达到 SOTA 水平，但他强调，其定性提升是一次重大阶跃，堪比从 Claude 4 到 4.5 的跨越。他特别指出该模型在长时间、高难度的解题任务上表现卓越，能够处…
+
+我把它放在这里，是因为：高信号观点但信息较短，更适合作为 Claude Fable 5 观察的补充。
+
+Claude · x.com · 发布时间：2026-06-10 02:10 · [原文](https://x.com/karpathy/status/2064409694761054332)
+
+### Anthropic 发布 Claude Fable 5：面向大众的 Mythos 级模型
+
+![Anthropic 发布 Claude Fable 5：面向大众的 Mythos 级模型](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_16.jpg)
+
+Anthropic 推出 Claude Fable 5，这是一款 Mythos 级模型，其能力超越此前所有公开发布的模型，且已通过安全测试可供大众使用。
+
+值得记下的点：
+- Anthropic 的官方 Claude 账号宣布发布 Claude Fable 5，一款全新的 Mythos 级 AI 模型。该模型的能力超越了 Anthropic 此前向公众开放的任何模型，并且经过专门设计和安全测试，可面向大众使用。这是该公司一次重大的产品发布。
+
+我把它放在这里，是因为：官方发布信息重要但偏公告，适合作为背景材料。
+
+Claude, Product · x.com · 发布时间：2026-06-10 01:08 · [原文](https://x.com/claudeai/status/2064394146916229443)
+
+### Claude Fable 5 与 Claude Mythos 5
+
+![Claude Fable 5 与 Claude Mythos 5](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_17.png)
+
+Anthropic 推出 Claude Fable 5，一款面向大众的 Mythos 级模型，具备最先进的能力；同时面向受信任的网络安全合作伙伴推出 Claude Mythos 5，并引入新的安全防护措施以降低滥用风险。
+
+值得记下的点：
+- Anthropic 宣布推出 Claude Fable 5，这是一款面向大众安全使用的 Mythos 级 AI 模型，以及 Claude Mythos 5——同一基础模型但解除了网络安全限制，通过 Project Glasswing 向有限的一批网络防御者和基础设施提供商开放。Fable 5 在几乎所有测试基准上均取得了最先进的结果，包括…
+- Claude Fable 5 是一款面向大众发布的最先进 Mythos 级模型，并配备了新的安全分类器。
+
+我把它放在这里，是因为：模型发布和安全边界信息完整，适合与实测文章对照阅读。
+
+Claude, AI Engineering, Memory · anthropic.com · 发布时间：2026-06-09 00:00 · [原文](https://www.anthropic.com/news/claude-fable-5-mythos-5)
+
+### 为什么编程是 AI 第一个无可否认的杀手级用例
+
+![为什么编程是 AI 第一个无可否认的杀手级用例](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_18.jpg)
+
+Benedict Evans 认为，智能体编程已经成为生成式 AI 第一个无可否认的应用场景，而更大的 AI 经济格局仍在模型差异化、企业工作流、软件价值捕获和基础设施投入之间悬而未决。
+
+值得记下的点：
+- 这场 a16z 与 Benedict Evans 的对谈，借助他的 AI Eats the World 框架，把当下 AI 采用的确定性与平台迁移中的诸多战略未知区分开来。Evans 认为，智能体编程之所以最先跑通，是因为开发者最早深度使用 LLM，也最自然地把它们用于软件开发，让原本只是有用的工具变成正在改变工程实践的能力。他进一步指出…
+- 智能体编程已经成为 AI 第一个无可否认的产品市场契合点 Evans 认为，编程最先爆发，是因为软件开发者最早成为 LLM 的重度用户，并且很自然地把它们用于自己的工作流，让一个曾经只是有用的工具真正开始改变工程实践。
+
+我把它放在这里，是因为：AI 编程杀手级用例的战略讨论，适合周末细读。
+
+AI Engineering, Product · youtube.com · 发布时间：2026-06-08 22:30 · [原文](https://www.youtube.com/watch?v=ktl8mNiWqMM)
+
+### OpenAI 如何打造 AI 原生财务团队：工程师嵌入、ChatGPT、Codex 与工作流智能体
+
+![OpenAI 如何打造 AI 原生财务团队：工程师嵌入、ChatGPT、Codex 与工作流智能体](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_19.jpg)
+
+OpenAI 财务负责人 Stacie Faggioli 介绍，公司如何把工程师、ChatGPT、Excel 智能体、Codex 仪表盘和工作流智能体嵌入财务流程，用更精简的团队运营 AI 原生财务组织。
+
+值得记下的点：
+- Stacie Faggioli 从 OpenAI 内部视角展示了公司如何围绕 AI 原生工作流建设未来的财务团队。她强调三条运营原则：重新设计流程，而不是把 AI 贴到旧流程上；用实际结果证明人效杠杆；尽早上线并快速迭代。随后她拆解了多类具体实践，包括用于大型融资尽调的投资者关系智能体、能生成可追溯 LBO 模型的 ChatGPT for…
+- AI 原生财务的起点，是围绕智能体重新设计工作流，而不是在旧流程上叠加 AI Faggioli 将 OpenAI 财务描述为从一开始就围绕 AI 构建的组织：流程设计、最佳实践扩散、与业务方协作，甚至组织架构规划，都把智能体作为基础能力来考虑。
+
+我把它放在这里，是因为：AI 原生职能团队案例，偏组织实践但有可迁移方法。
+
+Codex, AI Engineering, Business · youtube.com · 发布时间：2026-06-08 16:30 · [原文](https://www.youtube.com/watch?v=1NtS2KdnDok)
+
+### 程序间的博弈：竞争的规则学
+
+![程序间的博弈：竞争的规则学](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_20.png)
+
+本文通过穷举并测试重复双人博弈中所有可能的策略（有限状态机、元胞自动机、图灵机），系统探索了“竞争的规则学”，揭示了获胜策略既非一贯简单也非一贯复杂，而是取决于其详细结构。
+
+值得记下的点：
+- Stephen Wolfram 对程序间的竞争进行了全面的计算探索，将其构建为一门“规则学”——对所有可能规则的系统性研究。文章以“匹配或不匹配”（猜硬币）游戏为主要试验场，枚举了由 2 状态、3 状态和 4 状态有限状态机定义的所有可能策略，随后扩展到元胞自动机和图灵机。主要发现包括：获胜策略与行为复杂性之间没有强相关性；更大的机器可以…
+- 穷举所有可能策略表明，获胜与行为的简单性或复杂性无关。
+
+我把它放在这里，是因为：Wolfram 的规则学探索有理论趣味，但和日常 Agent 工程距离略远。
+
+人工智能 · writings.stephenwolfram.com · 发布时间：2026-06-05 01:54 · [原文](https://writings.stephenwolfram.com/2026/06/games-between-programs-the-ruliology-of-competition/)
+
+### 将 Gemma 4 12B 带到你的笔记本电脑：利用 Google AI Edge 解锁本地智能体工作流
+
+![将 Gemma 4 12B 带到你的笔记本电脑：利用 Google AI Edge 解锁本地智能体工作流](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-11/20260611215310_21.png)
+
+本文介绍了 Google 全新开源模型 Gemma 4 12B 与 Google AI Edge 技术栈的集成，使得在普通笔记本电脑上即可运行功能强大的、完全本地的智能体工作流。
+
+值得记下的点：
+- 本文宣布，Google DeepMind 的 Gemma 4 12B 模型现可通过 Google AI Edge 平台在本地设备上使用。文章重点介绍了三个关键应用：用于本地代码生成和数据可视化的 Google AI Edge Gallery 应用、用于语音听写和编辑的 Google AI Edge Eloquent 应用，以及新增了“se…
+- Gemma 4 12B 专为笔记本电脑上的本地、智能体及多模态工作流而设计。
+
+我把它放在这里，是因为：本地 Agent 工作流方向值得关注，但更像平台更新。
+
+Agent, Local AI · developers.googleblog.com · 发布时间：2026-06-03 08:00 · [原文](https://developers.googleblog.com/bringing-gemma-4-12b-to-your-laptop-unlocking-local-agentic-workflows-with-google-ai-edge/)
+
+## 略过但留档
+
+- **托尼·法德尔（Tony Fadell）产品构建的 10 大核心洞见**：产品判断力内容不错，但不是今日 AI 工程主线。（发布时间：2026-06-09 00:36 · [原文](https://x.com/lennysan/status/2064023777395237289)）
+- **iPod 与 iPhone 之父 Tony Fadell：AI 时代如何建立品味、判断力与创造力**：产品品味和判断力有启发，但与 ReadFlow 技术主题弱相关。（发布时间：2026-06-07 20:30 · [原文](https://www.youtube.com/watch?v=RJjl1TwyfWM)）
+- **Emergent：六个月 AI 折腾，如何催生一家 1 亿美元 ARR 公司**：创业故事信息量不错，但偏商业叙事。（发布时间：2026-06-06 20:30 · [原文](https://www.youtube.com/watch?v=yyXCQHX55N4)）
+- **给我 28 分钟，我会让你用更危险也更高效的方式学习任何东西**：学习方法内容可读，但偏个人成长。（发布时间：2026-06-06 08:54 · [原文](https://www.youtube.com/watch?v=ZLoBLGSX36c)）
+- **如何让反馈真正被听见：用情商提升职场领导力**：职场领导力主题与今日阅读目标不匹配。（发布时间：2026-06-05 23:00 · [原文](https://www.youtube.com/watch?v=OAIlucguNzY)）
+- **David Senra 研究 400+ 位创始人后学到的创业者底层模式**：创始人研究偏商业/人物，今日优先级较低。（发布时间：2026-06-04 20:00 · [原文](https://www.youtube.com/watch?v=xXsleu4-kd8)）
+- **⚡️萨提亚·纳德拉：Microsoft Build 上的 No Priors x Latent Space 特别跨界对话**：今天保留记录，但相对不如 Agent 工程主题直接。（发布时间：2026-06-04 01:13 · [原文](https://www.latent.space/p/satya-2026)）
+- **Alphabet 超额认购股权融资约 850 亿美元，其中伯克希尔·哈撒韦投资 100 亿美元**：融资快讯缺少可操作技术洞见。（发布时间：2026-06-04 00:04 · [原文](https://x.com/sundarpichai/status/2062203848673161267)）
+- **如何打造 AI 原生服务公司：YC 的创业者实战框架**：AI 服务公司框架有商业价值，但与技术主线相比优先级较低。（发布时间：2026-06-03 22:00 · [原文](https://www.youtube.com/watch?v=gSNFJbgoaHI)）
+
+## 今天的线索
+
+这一组内容的共同主题，是 Agent 从“会生成”继续走向“可执行、可协作、可验证”。知识层、Skill、MCP、多 Agent 协作和结果定价都在指向同一件事：真正有价值的 AI 系统，核心不只是模型，而是围绕模型建立起来的上下文、工具、约束和反馈闭环。


### PR DESCRIPTION
Closes #11

## Summary
- Add the ReadFlow Daily 2026-06-11 GitHub Pages post.
- Replace upstream image URLs with Tencent COS-hosted URLs.
- Keep only original article links and remove BestBlogs/read-page links.
- Include original article publication times for all entries.

## Verification
- ReadFlow tests passed: `python3 -m unittest tests.test_pipeline`
- Migration contract tests passed: `python3 -m unittest tests.test_ai_decision_migration_contract`
- Whitespace check passed: `git diff --check`
- Post check: 22 embedded images, all COS-hosted
- Post check: 0 BestBlogs links
- Post check: 30 original links and 30 publication-time labels

## Artifacts
- Post: `_posts/2026-06-11-readflow-daily.md`
- COS mapping: `/tmp/readflow-cos-2026-06-11.json`