### PR TITLE
Publish ReadFlow Daily 2026-06-13

### DIFF
--- a/_posts/2026-06-13-readflow-daily.md
+++ b/_posts/2026-06-13-readflow-daily.md
@@ -1,0 +1,401 @@
+---
+layout:     post
+title:      ReadFlow Daily 2026-06-13
+subtitle:   AI 阅读日报
+date:       2026-06-13
+author:     Eric.Y
+catalog: true
+tags:
+    - ReadFlow
+    - Daily
+    - Software Architecture
+    - Agent
+    - Harness
+    - AI Coding
+    - Coding Agent
+    - Context Engineering
+---
+
+# ReadFlow Daily 2026-06-13
+
+今天从 30 篇候选里留下 24 篇：11 篇进入今日重点，13 篇适合稍后细读。
+这份版本是给博客阅读的整理稿，只保留判断、摘要、配图和原文入口。
+
+![深度思考：架构腐朽 ＆ Loop Engineering](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_1.png)
+
+## 今日重点
+
+### 1. Kimi K2.7 Code 编程模型已上线 Kimi Code、API 开放平台
+
+![Kimi K2.7 Code 编程模型已上线 Kimi Code、API 开放平台](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_2.jpeg)
+
+Kimi K2.7 Code 是当天最直接的编程模型更新，包含长上下文、Agent 基准、token 成本和高速版路线。
+
+值得记下的点：
+- K2.7 Code 强化长程编程和指令遵循。
+- 平均 token 消耗下降约 30%，对实际 coding 成本有价值。
+- 高速版与 API 定价提供了可跟踪的产品信号。
+
+我把它放在这里，是因为：可作为国内 coding 模型进展的重点观察。
+
+AI Coding · mp.weixin.qq.com · 发布时间：2026-06-12 18:25 · [原文](https://mp.weixin.qq.com/s?__biz=Mzk0NDU1MDkyNg==&mid=2247488546&idx=1&sn=93d0057b04afc0c85495c6fd9a3b8516)
+
+### 2. 深度思考：架构腐朽 ＆ Loop Engineering
+
+![深度思考：架构腐朽 ＆ Loop Engineering](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_1.png)
+
+架构腐朽与 Loop Engineering 把软件排熵、约束执行和 AI Agent 反馈环放在同一框架下，贴合工程治理重点。
+
+值得记下的点：
+- 把“删除能力丧失”作为架构腐朽的判据。
+- 强调架构是持续执行的约束和可追溯理由链。
+- Loop Engineering 将 Agent 反馈环工程化为可观察、可验证机制。
+
+我把它放在这里，是因为：高度匹配架构、Agent 和工程约束兴趣，适合作为今日重点。
+
+Software Architecture, Agent · mp.weixin.qq.com · 发布时间：2026-06-12 08:27 · [原文](https://mp.weixin.qq.com/s?__biz=MzIzNjE2NTI3NQ==&mid=2247492054&idx=1&sn=f74c55856e852a32f090181a07b1eee8)
+
+### 3. AI 不缺智商缺纪律：一场 Harness 工程化实践
+
+![AI 不缺智商缺纪律：一场 Harness 工程化实践](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_3.jpeg)
+
+Harness 实践复盘直接讨论 AI Coding 如何从提示词堆叠走向分层约束、状态外置和确定性评测。
+
+值得记下的点：
+- 常驻入口层、原子规则层、按需上下文层降低上下文压力。
+- Dispatcher 与文件交接让 Agent 编排具备审计和续跑能力。
+- 确定性评分把 harness 迭代从感觉改为可比较。
+
+我把它放在这里，是因为：与 Agent 工程化和确定性门禁高度相关。
+
+Harness, AI Coding · mp.weixin.qq.com · 发布时间：2026-06-10 20:24 · [原文](https://mp.weixin.qq.com/s?__biz=Mzg4NTczNzg2OA==&mid=2247509774&idx=1&sn=02c8d0506c7d6ebc8fd58669160f1db3)
+
+### 4. 如何写好 Skill：一份终极实战经验手册
+
+![如何写好 Skill：一份终极实战经验手册](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_4.jpeg)
+
+腾讯 Skill 手册系统梳理 Description、渐进加载、示例、安全和 MCP/HTTP 集成，是可复用的技能工程材料。
+
+值得记下的点：
+- Skill 被定义为结构化 Prompt Engineering。
+- 高质量 Description、Few-Shot 和 Before/After 示例影响稳定性。
+- 复杂 Skill 需要模块化、脚本化检查和安全边界。
+
+我把它放在这里，是因为：Skill 工程直接匹配当前工作流和长期方法论。
+
+Skills, AI Coding · mp.weixin.qq.com · 发布时间：2026-06-05 17:36 · [原文](https://mp.weixin.qq.com/s?__biz=MjM5ODYwMjI2MA==&mid=2649801836&idx=1&sn=f01a69e0c012eafde5f8bc76804bc5fb)
+
+### 5. 人是最慢的节点，还怎么管 AI Agent？｜AI 跃迁者调研
+
+![人是最慢的节点，还怎么管 AI Agent？｜AI 跃迁者调研](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_5.png)
+
+Multica 访谈从 4 人团队和 Agent idle 率切入，讨论 AI Native 组织中人的监督位置和组织结构变化。
+
+值得记下的点：
+- 一人端到端与 Agent 协作平台重塑组织效率。
+- Agent idle 率是衡量 AI Native 程度的有趣指标。
+- 同时讨论信任、思考退化和独立判断风险。
+
+我把它放在这里，是因为：提供组织形态和 Agent 平台实践的双重视角。
+
+Agent, Organization · mp.weixin.qq.com · 发布时间：2026-06-11 17:50 · [原文](https://mp.weixin.qq.com/s?__biz=MjM5OTE0ODA2MQ==&mid=2650997592&idx=1&sn=102873946bcd8161798a0432b5d8c58d)
+
+### 6. 知识库分层编排：从 RAG 到 Agent-native Knowledge Context Layer
+
+![知识库分层编排：从 RAG 到 Agent-native Knowledge Context Layer](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_6.jpeg)
+
+金字塔知识库文章切中 Agent-native Knowledge Context Layer，把 RAG 粒度、层次和角色路由问题讲得系统。
+
+值得记下的点：
+- 五层知识结构对应不同稳定性和角色需求。
+- 分层关键词打分加图谱扩展降低从零推导成本。
+- 知识腐烂和保鲜周期是工程知识库的关键问题。
+
+我把它放在这里，是因为：高度匹配 Agent 知识层、上下文工程和本地化检索兴趣。
+
+Knowledge Layer, RAG · mp.weixin.qq.com · 发布时间：2026-06-10 08:30 · [原文](https://mp.weixin.qq.com/s?__biz=MzIzOTU0NTQ0MA==&mid=2247560713&idx=1&sn=fd6b0f4e8ce2b3bd20da9e0189170023)
+
+### 7. 微信发布 Skill 文档，数百万小程序，一夜之间变成了 AI 的手和脚
+
+![微信发布 Skill 文档，数百万小程序，一夜之间变成了 AI 的手和脚](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_7.png)
+
+微信 Skill 文档把小程序、MCP 和 AI 服务调用连接起来，是中文超级 App 进入 Agent 生态的重要平台信号。
+
+值得记下的点：
+- 微信 Skill 文档让小程序能力可被 AI 调用。
+- 事实加动作的接口规范和 ID 优先参数值得关注。
+- 微信具备中心化审核和小程序生态的独特分发优势。
+
+我把它放在这里，是因为：与 MCP、Skill 和平台级 Agent 入口强相关。
+
+MCP, WeChat · ifanr.com · 发布时间：2026-06-09 21:16 · [原文](https://www.ifanr.com/1668423?utm_source=rss&utm_medium=rss&utm_campaign=)
+
+### 8. AI 不会合作？那是因为他们没见过市场经济｜Hao 好聊趋势
+
+![AI 不会合作？那是因为他们没见过市场经济｜Hao 好聊趋势](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_8.png)
+
+AI 不会合作文章把多 Agent 协调失败、单体训练范式和市场机制结合，是理解 Agent 协作的重要材料。
+
+值得记下的点：
+- 多 Agent 失败来自协调崩溃与趋同推理。
+- Orchestrator-Worker 被批评为计划经济式架构。
+- 拍卖、支付和经济自然选择可能促进协作涌现。
+
+我把它放在这里，是因为：多 Agent 机制和经济学类比都很贴近当前关注。
+
+Multi-Agent, Economics · mp.weixin.qq.com · 发布时间：2026-06-07 20:21 · [原文](https://mp.weixin.qq.com/s?__biz=Mjc1NjM3MjY2MA==&mid=2691569024&idx=1&sn=1a73a60848e59c69ffc6c066c314a872)
+
+### 9. 如何更科学、方向可控的实现 Skill 的“自进化”?
+
+![如何更科学、方向可控的实现 Skill 的“自进化”?](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_6.jpeg)
+
+Skill 自进化文章比较 Trace2Skill、EvoSkill、SkillOpt，聚焦可控、可验证的技能迭代机制。
+
+值得记下的点：
+- Trace2Skill 从大量轨迹归纳通用 Skill。
+- EvoSkill 通过执行、提案、构建、验证闭环控制方向。
+- SkillOpt 将 Skill 文本类比参数，引入学习率和验证门控。
+
+我把它放在这里，是因为：与技能生态、自动改进和企业稳定性强相关。
+
+Skill Evolution, Agent · mp.weixin.qq.com · 发布时间：2026-06-09 08:30 · [原文](https://mp.weixin.qq.com/s?__biz=MzIzOTU0NTQ0MA==&mid=2247560712&idx=1&sn=8c34bc7fe0e1213ec696996dc34f9fba)
+
+### 10. 横向拆解 Claude Code、Codex 等六大 Agent 上下文压缩策略后，我们做了第 7 个
+
+![横向拆解 Claude Code、Codex 等六大 Agent 上下文压缩策略后，我们做了第 7 个](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_4.jpeg)
+
+上下文压缩策略横评直接覆盖 Claude Code、Codex CLI 等 Agent，提炼水位线、增量摘要和近端保护原则。
+
+值得记下的点：
+- 分层渐进和成本递增是主流压缩共识。
+- 用户消息特权、近端保护和单调边界是关键安全线。
+- 四级水位线方案适合云端多用户 Agent 场景。
+
+我把它放在这里，是因为：与 Codex/Claude Code 上下文工程高度相关。
+
+Context Engineering, Codex · mp.weixin.qq.com · 发布时间：2026-06-08 17:36 · [原文](https://mp.weixin.qq.com/s?__biz=MjM5ODYwMjI2MA==&mid=2649801845&idx=1&sn=25c1772d233048ad058811b25ff90a5b)
+
+### 11. Coding Agent 技术全景图：Context Engineering、Subagents 与 Harness，一年范式转移全解析
+
+![Coding Agent 技术全景图：Context Engineering、Subagents 与 Harness，一年范式转移全解析](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_9.jpeg)
+
+Coding Agent 技术全景图系统梳理 Context Engineering、Subagents、Harness 和低监督风险，是今日最完整的 Agent 工程综述。
+
+值得记下的点：
+- Context Engineering 成为放大工程实践的杠杆。
+- 低监督开发需要按概率、影响、可检测性评估风险。
+- Harness Engineering 用确定性工具和测试约束非确定性输出。
+
+我把它放在这里，是因为：高度匹配 AI coding、Agent 工程和安全边界。
+
+Coding Agent, Harness · mp.weixin.qq.com · 发布时间：2026-06-07 10:15 · [原文](https://mp.weixin.qq.com/s?__biz=MjM5MDE0Mjc4MA==&mid=2651286556&idx=1&sn=e20fc46413fcb8fae553d416e38598d6)
+
+## 值得细读
+
+### 科技爱好者周刊（第 400 期）：rsync 的争论
+
+![科技爱好者周刊（第 400 期）：rsync 的争论](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_10.webp)
+
+阮一峰周刊用 rsync 争议串起 AI 生成代码、开源维护和测试责任，是很好的背景读物。
+
+值得记下的点：
+- rsync 维护者选择让 AI 写补丁、人类强化测试。
+- 开源项目将面对 AI 发现漏洞和 AI 修复漏洞的双重压力。
+- 周刊还附带多条技术动态和工具线索。
+
+我把它放在这里，是因为：值得稍后细读，但内容是综合周刊，主题密度低于专门文章。
+
+Open Source, AI Coding · ruanyifeng.com · 发布时间：2026-06-12 07:26 · [原文](http://www.ruanyifeng.com/blog/2026/06/weekly-issue-400.html)
+
+### Xiaomi MiMo 携手 TileRT｜1T 模型首次突破 1000 tokens/s 输出速度
+
+![Xiaomi MiMo 携手 TileRT｜1T 模型首次突破 1000 tokens/s 输出速度](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_11.jpeg)
+
+MiMo 与 TileRT 的 1T 模型高速推理案例提供了 FP4 量化、DFlash 投机解码和系统协同设计的技术细节。
+
+值得记下的点：
+- 通用 8 卡 GPU 上实现 1000+ tokens/s 输出。
+- FP4 混合量化仅处理 MoE Expert 以控制精度损失。
+- DFlash 和 TileRT 体现模型-系统 codesign 的路线。
+
+我把它放在这里，是因为：推理系统方向很有价值，但偏发布稿，放入细读。
+
+Inference, LLM · mp.weixin.qq.com · 发布时间：2026-06-09 11:32 · [原文](https://mp.weixin.qq.com/s?__biz=Mzk3NTkxMTM2NA==&mid=2247484770&idx=1&sn=d73555bb9ccb345204f0e86cb567c361)
+
+### 普渡机器人创始人张涛：打造具身智能时代的 AI 原生组织
+
+![普渡机器人创始人张涛：打造具身智能时代的 AI 原生组织](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_8.png)
+
+普渡机器人创始人访谈把具身智能、商业化能力和 AI 原生组织联系起来，适合跟踪机器人公司组织演进。
+
+值得记下的点：
+- 提出数据、算法、算力作为个人与组织成长模型。
+- 管理金字塔覆盖创始人、流程、英雄联盟和 AI 原生模式。
+- 机器人行业竞争被归结为商业化能力。
+
+我把它放在这里，是因为：具身智能和组织建设相关，但文章偏人物访谈。
+
+Robotics, AI Organization · mp.weixin.qq.com · 发布时间：2026-06-10 18:28 · [原文](https://mp.weixin.qq.com/s?__biz=Mjc1NjM3MjY2MA==&mid=2691569123&idx=1&sn=0253fd12b7e60ed9d95dc8dab641e77b)
+
+### 只给一份文档，Qwen3.7-Max 从 0 交付双端应用
+
+![只给一份文档，Qwen3.7-Max 从 0 交付双端应用](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_12.jpeg)
+
+Qwen3.7-Max 从产品调研文档交付双端应用，重点在约束闭环和分层验收，适合观察自动软件交付边界。
+
+值得记下的点：
+- 仅凭长文档完成规划、架构、编码和验证。
+- 分阶段注入约束与分层验收是核心方法。
+- 实验展示了从 0 到 1 的 Agent 工程路径。
+
+我把它放在这里，是因为：主题相关，但偏实验展示，暂列细读。
+
+AI Coding, Evaluation · mp.weixin.qq.com · 发布时间：2026-06-09 17:28 · [原文](https://mp.weixin.qq.com/s?__biz=MzkxMTYyMTAzNA==&mid=2247501453&idx=1&sn=ba96a013175e2587878e1b2e00c9ab73)
+
+### 4000 行代码撑起一个 Agent 框架？nanobot 架构深度解析
+
+![4000 行代码撑起一个 Agent 框架？nanobot 架构深度解析](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_13.png)
+
+nanobot 的 4000 行 Agent 框架解析提供极简 ReAct、Markdown Skill 和文件记忆的架构权衡。
+
+值得记下的点：
+- 集中化 AgentLoop 提升可理解性。
+- Tool 接口统一为 str 降低复杂度但牺牲类型信息。
+- 基于文件和 grep 的记忆简单可审计但有规模上限。
+
+我把它放在这里，是因为：框架设计有借鉴价值，适合细读。
+
+Agent Framework · mp.weixin.qq.com · 发布时间：2026-06-09 08:45 · [原文](https://mp.weixin.qq.com/s?__biz=MzI2NDU4OTExOQ==&mid=2247695857&idx=1&sn=7c2f39eed5649d1ef2ddc47fd767b1fe)
+
+### 对话 MiniMax 择因：Agent 终会超过人类，我们又将何去何从？
+
+![对话 MiniMax 择因：Agent 终会超过人类，我们又将何去何从？](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_14.png)
+
+MiniMax Agent Team 访谈讨论 Leader-Worker-Verifier、状态机和对抗验证，和多 Agent 编排实践相关。
+
+值得记下的点：
+- Leader-Worker-Verifier 缓解长程任务的上下文污染。
+- 状态机与上下文隔离是工程重点。
+- 行业共识从模型竞争转向脚手架竞争。
+
+我把它放在这里，是因为：方向匹配，但访谈形式信息密度略低于专门技术文。
+
+Agent Team · ifanr.com · 发布时间：2026-06-08 21:15 · [原文](https://www.ifanr.com/1668337?utm_source=rss&utm_medium=rss&utm_campaign=)
+
+### 英伟达：带领 PC，重铸 PC｜硬哲学
+
+![英伟达：带领 PC，重铸 PC｜硬哲学](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_15.jpg)
+
+英伟达面向智能体重塑 PC 的文章提供消费级 AI PC 和 Windows on ARM 生态信号。
+
+值得记下的点：
+- 硬件设计从面向人类转向面向智能体。
+- RTX Spark N1X 把 CUDA/RTX/DLSS 带到 ARM PC 叙事中。
+- 文章也提示技术代际和生态风险。
+
+我把它放在这里，是因为：产业信号值得跟踪，但与软件 Agent 工程距离稍远。
+
+AI Hardware, NVIDIA · ifanr.com · 发布时间：2026-06-08 19:59 · [原文](https://www.ifanr.com/1668041?utm_source=rss&utm_medium=rss&utm_campaign=)
+
+### Kimi Work 不是中国版 Codex
+
+![Kimi Work 不是中国版 Codex](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_8.png)
+
+Kimi Work 文章把本地通用 Agent、WebBridge、Agent 集群和 Skill 广场放在知识工作场景中分析。
+
+值得记下的点：
+- Kimi Work 面向知识工作者而不是程序员。
+- WebBridge 让 AI 能执行浏览器操作。
+- Skill 广场和专业数据库拓展办公 Agent 能力。
+
+我把它放在这里，是因为：有产品形态和 Agent 能力泛化观察价值。
+
+Agent Product, Kimi · mp.weixin.qq.com · 发布时间：2026-06-08 15:29 · [原文](https://mp.weixin.qq.com/s?__biz=Mjc1NjM3MjY2MA==&mid=2691569060&idx=1&sn=4c910ca78a10c98917fb7b834e13676d)
+
+### “Token 经济”进入结果层
+
+![“Token 经济”进入结果层](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_8.png)
+
+Token 经济进入结果层讨论 AI 从按量计费转向按结果付费，适合理解 Agent 商业模式。
+
+值得记下的点：
+- 结果定价需要定义完成、证明贡献、计算费用和分配责任。
+- 结果型 AI 会从工具箱变成执行系统。
+- 高频、边界清晰、可验收场景更适合结果付费。
+
+我把它放在这里，是因为：商业模式相关，信息密度不错但不是今日最核心工程主题。
+
+AI Business, Pricing · mp.weixin.qq.com · 发布时间：2026-06-08 08:40 · [原文](https://mp.weixin.qq.com/s?__biz=Mjc1NjM3MjY2MA==&mid=2691569039&idx=1&sn=800b2c88efe0d1f5ebb8db1fc0be6cc0)
+
+### Vol.121｜硅谷 AI 大转弯，软件正在死去，创业者的真机会在哪里？｜2026 年中特辑
+
+![Vol.121｜硅谷 AI 大转弯，软件正在死去，创业者的真机会在哪里？｜2026 年中特辑](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_16.png)
+
+硅谷 AI 年中特辑从模型战争、应用被吞噬和具身智能路线讨论创业机会，适合产业判断。
+
+值得记下的点：
+- Anthropic 在 Coding 上暂时领先，Google 生态和算力被低估。
+- 创业者应避开依赖旗舰模型智能的套壳应用。
+- 具身智能的数据飞轮仍未收敛。
+
+我把它放在这里，是因为：产业和投资视角有价值，但篇幅长、播客整理优先级稍低。
+
+AI Industry, Startup · xiaoyuzhoufm.com · 发布时间：2026-06-08 14:34 · [原文](https://www.xiaoyuzhoufm.com/episode/6a265d55b30e1571aea280f5)
+
+### 对阳萌的 4 小时访谈：消费电子死与生、第三类公司、AI 变量、产品方法、打游戏的模式选择
+
+![对阳萌的 4 小时访谈：消费电子死与生、第三类公司、AI 变量、产品方法、打游戏的模式选择](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_17.png)
+
+阳萌访谈把消费电子战略、深科技投入和 AI 原生组织联系起来，适合观察硬件公司转型。
+
+值得记下的点：
+- 从 Easy 模式到 Hard 模式的创业路径有方法论价值。
+- 五系到七系转型本质是组织心智切换。
+- AI 原生组织会改变小团队、角色融合和价值分配。
+
+我把它放在这里，是因为：组织与产品方法有价值，但不是纯 AI 技术文章。
+
+AI Organization, Consumer Electronics · xiaoyuzhoufm.com · 发布时间：2026-06-08 08:00 · [原文](https://www.xiaoyuzhoufm.com/episode/6a2543dcb30e1571aea20d0b)
+
+### 对话奇点灵智：少儿 AI 硬件的下一代，不是 Chatbot，而是能自进化的实体智能体
+
+![对话奇点灵智：少儿 AI 硬件的下一代，不是 Chatbot，而是能自进化的实体智能体](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_18.png)
+
+少儿 AI 硬件访谈展示 Agentic OS、AI Coding 和实体智能体在儿童教育场景的落地。
+
+值得记下的点：
+- AI 硬件应从内容生成走向能力生成。
+- 摄像头、屏幕、按钮被封装为 AI 可调用工具。
+- 双用户需求要求同时满足孩子体验和家长学习交付。
+
+我把它放在这里，是因为：垂直场景完整，但偏教育硬件产品。
+
+AI Hardware, Education · mp.weixin.qq.com · 发布时间：2026-06-07 10:30 · [原文](https://mp.weixin.qq.com/s?__biz=Mzg5NTc0MjgwMw==&mid=2247524534&idx=1&sn=2f7576a63d4e48931bbd6cb2fe125430)
+
+### 最新对话“AI 教父”辛顿：超级智能即将到来 | 完整版+视频
+
+![最新对话“AI 教父”辛顿：超级智能即将到来 | 完整版+视频](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-13/20260613105359_19.png)
+
+辛顿访谈集中在超级智能、数字智能优势和监管方向，提供 AI 安全和社会风险背景。
+
+值得记下的点：
+- 辛顿认为大语言模型已具备理解力。
+- 数字智能副本共享信息的效率远高于生物智能。
+- 利润驱动竞争可能削弱安全约束。
+
+我把它放在这里，是因为：安全背景重要，但可操作工程含量不如今日重点。
+
+AI Safety, AGI · mp.weixin.qq.com · 发布时间：2026-06-06 20:18 · [原文](https://mp.weixin.qq.com/s?__biz=MzIxODUzNTg2MA==&mid=2247492063&idx=1&sn=e0a2f94b60f2e8375cf768d0ab174d5e)
+
+## 略过但留档
+
+- **SpaceX 敲钟，马斯克成人类首个“万亿美元先生”，400 名员工身家过亿**：产业新闻可留档，但不进入今日重点。（发布时间：2026-06-13 00:20 · [原文](https://mp.weixin.qq.com/s?__biz=Mjc1NjM3MjY2MA==&mid=2691569263&idx=1&sn=a3576c3ea43bea298310f379d3676d96)）
+- **Kimi 将公开预测 104 场世界杯赛事：德国队或爆冷夺冠**：和核心 AI 工程兴趣相邻但不够强。（发布时间：2026-06-08 19:28 · [原文](https://mp.weixin.qq.com/s?__biz=Mzk0NDU1MDkyNg==&mid=2247488523&idx=1&sn=2f3f79f943ff9df29ea3df0dc013685e)）
+- **跨端页面秒开，腾讯开源框架 Kuikly 是怎么做到的？**：保留留档，今天不作为重点。（发布时间：2026-06-10 17:37 · [原文](https://mp.weixin.qq.com/s?__biz=MjM5ODYwMjI2MA==&mid=2649801924&idx=1&sn=319b28177b03a56e9d63b61285e5606b)）
+- **S9E4 鲁豫对话蒙曼 | 生命不要早知如此，我决定更勇敢**：内容本身完整，但不适合 ReadFlow 今日技术筛选。（发布时间：2026-06-10 08:00 · [原文](https://www.xiaoyuzhoufm.com/episode/6a27f68a41404ca3b66736b6)）
+- **iPhone 终于支持 Siri AI！但国行无缘首发，闹钟成为最大惊喜**：保留留档，不进入今日重点。（发布时间：2026-06-09 13:20 · [原文](https://www.ifanr.com/1668385?utm_source=rss&utm_medium=rss&utm_campaign=)）
+- **对话凯文·凯利：人类将如何与 AI 一起走向 2049？丨首席评论**：作为思想背景可留档，今天不优先。（发布时间：2026-06-07 08:00 · [原文](https://www.xiaoyuzhoufm.com/episode/6a1fe57eb30e1571ae9ffbb3)）
+
+## 今天的线索
+
+这一组内容的共同主题，是 Agent 从“会生成”继续走向“可执行、可协作、可验证”。知识层、Skill、MCP、多 Agent 协作和结果定价都在指向同一件事：真正有价值的 AI 系统，核心不只是模型，而是围绕模型建立起来的上下文、工具、约束和反馈闭环。


### PR DESCRIPTION
Closes #13

## Summary
- Publish the generated ReadFlow Daily post for 2026-06-13.
- Use the COS-rewritten Markdown generated by the ReadFlow workflow.

## Verification
- ReadFlow audit: success
- Candidate/decision count: 30/30
- Decision breakdown: keep 11, close_read 13, low_priority 5, reject 1
- GitHub Pages post: Jekyll frontmatter present
- Public links: 30 original article links, no BestBlogs/read-page links
- Publication times: 30 labels present
- Pipeline fields: none found in public post
- Images: 25 embedded images in the post, all under https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/
- COS mapping: /Users/akai/codes/SarKerson/readflow/data/processed/2026-06-13/cos-image-mapping.json with 19 successful uploads and 0 errors

## Validation gaps
- Live GitHub Pages render not tested before merge.