### PR TITLE
Publish ReadFlow Daily 2026-06-16

### DIFF
--- a/_posts/2026-06-16-readflow-daily.md
+++ b/_posts/2026-06-16-readflow-daily.md
@@ -1,0 +1,20 @@
+---
+layout:     post
+title:      ReadFlow Daily 2026-06-16
+subtitle:   AI 阅读日报
+date:       2026-06-16
+author:     Eric.Y
+catalog: true
+tags:
+    - ReadFlow
+    - Daily
+---
+
+# ReadFlow Daily 2026-06-16
+
+今天从 0 篇候选里留下 0 篇：0 篇进入今日重点，0 篇适合稍后细读。
+这份版本是给博客阅读的整理稿，只保留判断、摘要、配图和原文入口。
+
+## 今天的线索
+
+这一组内容的共同主题，是 Agent 从“会生成”继续走向“可执行、可协作、可验证”。知识层、Skill、MCP、多 Agent 协作和结果定价都在指向同一件事：真正有价值的 AI 系统，核心不只是模型，而是围绕模型建立起来的上下文、工具、约束和反馈闭环。


### PR DESCRIPTION
Closes #18

## Summary

Publishes the generated ReadFlow Daily GitHub Pages post for 2026-06-16.

Today's Asia/Shanghai ReadFlow run produced zero new candidates after FreshRSS fetch and seen-article filtering, so this is a no-new-items daily artifact.

## Verification

- `python3 scripts/readflow/run_daily.py --date 2026-06-16 --limit 30`
- `python3 scripts/readflow/finalize_daily.py --date 2026-06-16`
- Audit status: `success`
- Candidate count: `0`
- Decision count: `0`
- Decision breakdown: `{}`
- Public Markdown checks passed: no BestBlogs/read-page links, no pipeline-only fields, and all embedded images satisfy the COS URL invariant.
- COS mapping artifact: `data/processed/2026-06-16/cos-image-mapping.json` (empty because no images were embedded).

## Validation Gap

No live GitHub Pages render was tested after merge. Publication-time and original-link checks are vacuous today because the candidate set is empty.

No `ready-for-agent`, `codex`, or `codex-automation` labels were applied because this repository currently exposes only the default GitHub labels.