### PR TITLE
Publish ReadFlow Daily 2026-06-18

### DIFF
--- a/_posts/2026-06-18-readflow-daily.md
+++ b/_posts/2026-06-18-readflow-daily.md
@@ -1,0 +1,41 @@
+---
+layout:     post
+title:      ReadFlow Daily 2026-06-18
+subtitle:   AI 阅读日报
+date:       2026-06-18
+author:     Eric.Y
+catalog: true
+tags:
+    - ReadFlow
+    - Daily
+    - AI
+    - Coding Agent
+    - Open Source Model
+    - GLM
+---
+
+# ReadFlow Daily 2026-06-18
+
+今天从 1 篇候选里留下 1 篇：1 篇进入今日重点，0 篇适合稍后细读。
+这份版本是给博客阅读的整理稿，只保留判断、摘要、配图和原文入口。
+
+![GLM-5.2 上线并开源：专注 Coding 与长程任务](https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/blog/readflow/2026-06-18/20260618043351_1.jpeg)
+
+## 今日重点
+
+### 1. GLM-5.2 上线并开源：专注 Coding 与长程任务
+
+智谱发布并开源 GLM-5.2，重点强化 Coding、长程任务和 1M 上下文能力，文章给出了基准表现、基础设施优化和 Agent 应用方向。它适合作为今天关注国产开源 Coding 模型进展的主条目。
+
+值得记下的点：
+- GLM-5.2 在 Code Arena 前端开发盲测中取得全球可用模型第一，并在 Terminal-Bench、MCP-Atlas 等基准上保持开源 SOTA。
+- 模型强调 1M 上下文稳定性、IndexShare 稀疏注意力、改进投机解码和 Slime 训练框架等长程任务基础设施。
+- MIT 开源协议和国产算力 Day 0 适配降低了企业与开发者尝试门槛，也指向后续自治智能体产品化。
+
+我把它放在这里，是因为：主题与 AI 编程模型、长上下文和 Agent 工程化高度相关，摘要信息完整且具备当日新闻价值。
+
+AI, Coding Agent, Open Source Model, GLM · mp.weixin.qq.com · 发布时间：2026-06-17 09:11 · [原文](https://mp.weixin.qq.com/s?__biz=MzkyMzI3NzQ0Mg==&mid=2247493980&idx=1&sn=995ae194e71d723b6110fb8c621e618c)
+
+## 今天的线索
+
+这一组内容的共同主题，是 Agent 从“会生成”继续走向“可执行、可协作、可验证”。知识层、Skill、MCP、多 Agent 协作和结果定价都在指向同一件事：真正有价值的 AI 系统，核心不只是模型，而是围绕模型建立起来的上下文、工具、约束和反馈闭环。


### PR DESCRIPTION
Closes #23

## Summary

Publishes the generated ReadFlow Daily post for 2026-06-18.

## Verification

- Ran `python3 scripts/readflow/finalize_daily.py --date 2026-06-18` in the ReadFlow repo.
- Audit status: success.
- Candidate count: 1.
- Decision count: 1.
- Decision breakdown: `keep: 1`.
- Verified Obsidian and GitHub Pages drafts include original article publication time.
- Verified public drafts link only to the original article URL.
- Verified no BestBlogs/read-page links, pipeline-only fields, or aggregator metadata fields are present.
- Uploaded the source RSS image to Tencent COS and embedded the COS URL in both Markdown files.
- Verified every embedded Markdown image points at `https://obsidian-1254275759.cos.ap-shanghai.myqcloud.com/`.
- COS mapping recorded at `/Users/akai/codes/SarKerson/readflow/data/processed/2026-06-18/cos-image-mapping.json` and `/tmp/readflow-cos-2026-06-18.json`.

## Scope

Only `_posts/2026-06-18-readflow-daily.md` is included in this PR.