### PR TITLE
Publish ReadFlow Weekly 2026-W25

### DIFF
--- a/_posts/2026-06-21-readflow-weekly.md
+++ b/_posts/2026-06-21-readflow-weekly.md
@@ -1,0 +1,54 @@
+---
+layout: post
+title: ReadFlow Weekly 2026-W25
+date: 2026-06-21 20:30:00 +0800
+categories: [ReadFlow]
+---
+
+这周的 RSS 候选明显集中在一个方向：AI 已经从“能不能写代码”进入“怎样被工程化、审查、授权和组织化使用”的阶段。最值得看的不是单点模型新闻，而是围绕 agent、上下文、权限和工程纪律形成的一组实践信号。
+
+## 本周主线：AI 工程回到系统工程
+
+### 持续授权不再是安全附加项
+
+[为敏感云系统设计持续授权](https://www.infoq.com/articles/continuous-authorization-cloud)，发布时间：2026-06-19 17:00。
+
+这篇文章把授权从“登录时的角色检查”推进到“每个敏感操作发生时的上下文判断”。对 AI 应用尤其有启发：当工具调用、数据访问和跨租户操作被模型串起来，静态 RBAC 很容易变成过期许可。更稳的方向是把行为基线、环境信号、数据敏感度和角色规范放进运行时策略决策中，并为每次高风险动作留下可审计证据。
+
+### 代码审查成为 AI 编程的关键瓶颈
+
+[智能体代码审查](https://addyo.substack.com/p/agentic-code-review)，发布时间：2026-06-16 22:31。
+
+AI 让代码生成速度上升后，真正稀缺的能力变成判断：这段代码是否可信，改动是否符合系统边界，测试是否证明了关键行为。文章的价值在于把 review 从“读 diff”提升为工程控制点：审查者需要验证需求、风险、状态迁移和可回滚性，而不是被生成速度牵着走。
+
+### AI 需要更多工程纪律
+
+[AI 需要更多工程纪律，而非更少](https://charitydotwtf.substack.com/p/ai-demands-more-engineering-discipline)，发布时间：2026-06-15 13:35。
+
+这篇文章和代码审查主题互相呼应。AI 生成代码越便宜，系统越需要明确边界、可执行测试、可观察性和共享上下文。真正的问题不是“写代码成本下降”，而是非确定性输入进入工程系统后，团队是否仍能保持设计约束和行为账本。
+
+### 上下文工程是新的基础设施层
+
+[超越提示词：面向大规模 AI 系统的上下文工程与记忆管理](https://www.infoq.com/presentations/context-engineering-data)，发布时间：2026-06-10 20:03。
+
+这篇 InfoQ 演讲把“大模型应用”重新描述成状态、检索、记忆和事件流问题。提示词只是表层，真正决定系统质量的是上下文如何进入、如何更新、如何过期、如何被审计。对长期运行的 agent 系统来说，这比一次性 prompt 技巧重要得多。
+
+### AI 原生工程组织不是工具替换
+
+[打造 AI 原生工程组织](https://claude.com/blog/running-an-ai-native-engineering-org)，发布时间：2026-06-03 00:00。
+
+Claude Code 团队的经验说明，AI 原生不是“每个人装一个编码助手”这么简单。规划、上下文收集、代码审查、团队角色和交付节奏都会变化。更好的组织会把 agent 当成工程流程的一部分，而不是把它放在流程之外临时加速。
+
+## 值得顺手看的补充
+
+- [TypeScript 7.0 RC 发布公告 - TypeScript](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-rc)，发布时间：2026-06-18 22:31。TypeScript 7.0 RC 的 Go 编译器迁移展示了成熟工具链在性能和兼容性之间的工程取舍。
+- [循环工程的艺术](https://www.langchain.com/blog/the-art-of-loop-engineering)，发布时间：2026-06-16 08:00。Loop engineering 提供了把 agent loop、验证 loop 和事件 loop 分层设计的实用语言。
+- [AI 智能体工具设计：有效与无效的模式 - MachineLearningMastery.com](https://machinelearningmastery.com/ai-agent-tool-design-what-works-and-what-doesnt)，发布时间：2026-06-15 20:51。工具设计文章把 agent 失败归因到接口边界，而不是单纯模型能力。
+- [为什么 AI 还没有取代软件工程师，而且也不会](https://www.normaltech.ai/p/why-ai-hasnt-replaced-software-engineers)，发布时间：2026-06-11 10:29。“AI 不会取代软件工程师”的文章用决策、执行和交付责任解释了软件工作的剩余人类价值。
+- [智能体与应用之间缺失的环节](https://www.langchain.com/blog/agents-and-applications)，发布时间：2026-06-10 08:00。LangChain 的 headless tools 把客户端能力纳入 agent loop，补上服务端推理和本地应用状态之间的断层。
+- [我们如何构建 Cloudflare 的数据平台及其上的 AI 智能体](https://blog.cloudflare.com/our-unified-data-platform)，发布时间：2026-05-28 22:00。Cloudflare 的数据平台和 Skipper 展示了企业内部数据 agent 所需的权限、语义和审计底座。
+- [Airtable 如何为 AI 功能构建搜索层](https://blog.bytebytego.com/p/how-airtable-built-the-search-layer)，发布时间：2026-05-27 23:30。Airtable 的向量搜索层是多租户 AI 功能背后很现实的基础设施案例。
+
+## 本周判断
+
+这一周最清楚的信号是：AI 工程的注意力正在从模型能力转向操作边界。授权、review、上下文、工具接口、数据平台和组织流程都在变成一等问题。未来真正有复利的不是多试几个模型，而是把这些边界沉淀成可运行、可检查、可交接的系统。


### PR DESCRIPTION
Closes #29

Publishes the real ReadFlow RSS weekly post for 2026-W25.

Validation:
- candidate_count=100
- decision_count=100
- decision breakdown: feature=5, mention=7, archive=82, reject=6
- validation_gaps=[]
- public Markdown scan: no BestBlogs/read-page links, no pipeline-only fields, no embedded images
- staged scope: only _posts/2026-06-21-readflow-weekly.md

Issue: https://github.com/SarKerson/SarKerson.github.io/issues/29