### PR TITLE
Publish ReadFlow Daily 2026-06-23

### DIFF
--- a/_posts/2026-06-23-readflow-daily.md
+++ b/_posts/2026-06-23-readflow-daily.md
@@ -1,0 +1,20 @@
+---
+layout:     post
+title:      ReadFlow Daily 2026-06-23
+subtitle:   AI 阅读日报
+date:       2026-06-23
+author:     Eric.Y
+catalog: true
+tags:
+    - ReadFlow
+    - Daily
+---
+
+# ReadFlow Daily 2026-06-23
+
+今天从 0 篇候选里留下 0 篇：0 篇进入今日重点，0 篇适合稍后细读。
+这份版本是给博客阅读的整理稿，只保留判断、摘要、配图和原文入口。
+
+## 今天的线索
+
+这一组内容的共同主题，是 Agent 从“会生成”继续走向“可执行、可协作、可验证”。知识层、Skill、MCP、多 Agent 协作和结果定价都在指向同一件事：真正有价值的 AI 系统，核心不只是模型，而是围绕模型建立起来的上下文、工具、约束和反馈闭环。


### PR DESCRIPTION
Closes #33

## Verification
- Ran `python3 scripts/readflow/finalize_daily.py --date 2026-06-23` in `/Users/akai/codes/SarKerson/readflow`.
- Audit succeeded: candidate_count=0, decision_count=0, status=success.
- Generated Obsidian copy: `/Users/akai/codes/SarKerson/notes/Blogging/2026/daily/2026-06-23.md`.
- Generated GitHub Pages post: `_posts/2026-06-23-readflow-daily.md`.
- Verified both public Markdown files contain no BestBlogs/read-page links and no pipeline-only fields.
- Verified both public Markdown files contain zero embedded images; COS mapping is `/Users/akai/codes/SarKerson/readflow/data/processed/2026-06-23/cos-image-mapping.json` with `{}`.
- Committed only `_posts/2026-06-23-readflow-daily.md` in this repo.

## Notes
The same-day candidate artifacts were already present and empty, so there were no article links or original publication times to render. The repo does not have `codex` or `codex-automation` labels available, so no PR labels were applied.